### PR TITLE
update to support AtomsBase 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteratomicPotentials"
 uuid = "a9efe35a-c65d-452d-b8a8-82646cd5cb04"
 authors = ["Dallas Foster <fostdall@mit.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -17,6 +17,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
+AtomsBase = "0.2"
 ExtXYZ = "0.1"
 LAMMPS = "0.1"
 julia = "1.6"

--- a/src/PotentialTypes/EmpiricalPotentials/vectorization.jl
+++ b/src/PotentialTypes/EmpiricalPotentials/vectorization.jl
@@ -1,6 +1,6 @@
 # ############################## Energy ################################
 
-function potential_energy(a::StaticAtom, p::EmpiricalPotential)
+function potential_energy(a::AtomsBase.Atom, p::EmpiricalPotential)
     return potential_energy(ustrip.(a.position), p)
 end
 
@@ -20,7 +20,7 @@ function potential_energy(a::AbstractSystem, p::EmpiricalPotential)
 end
 
 # ############################## Force ################################
-function force(a::StaticAtom, p::EmpiricalPotential)
+function force(a::AtomsBase.Atom, p::EmpiricalPotential)
     return force(ustrip.(a.position), p)
 end
 
@@ -44,7 +44,7 @@ function force(s::AbstractSystem, p::EmpiricalPotential)
     return SVector{n}([SVector{3}(fi) for fi in f])
 end
 # ############################## Virial ################################
-function virial(a::StaticAtom, p::EmpiricalPotential)
+function virial(a::AtomsBase.Atom, p::EmpiricalPotential)
     return virial(ustrip.(a.position), p)
 end
 
@@ -63,7 +63,7 @@ function virial(S::AbstractSystem, p::EmpiricalPotential)
     return v
 end
 
-function virial_stress(a::StaticAtom, p::EmpiricalPotential)
+function virial_stress(a::AtomsBase.Atom, p::EmpiricalPotential)
     return virial_stress(ustrip.(a.position), p)
 end
 

--- a/src/PotentialTypes/EmpiricalPotentials/vectorization.jl
+++ b/src/PotentialTypes/EmpiricalPotentials/vectorization.jl
@@ -1,19 +1,18 @@
 # ############################## Energy ################################
 
 function potential_energy(a::AtomsBase.Atom, p::EmpiricalPotential)
-    return potential_energy(ustrip.(a.position), p)
+    return potential_energy(ustrip.(position(a)), p)
 end
 
 function potential_energy(a::AbstractSystem, p::EmpiricalPotential)
     pe = 0.0
-    r = a.particles
-    N = length(r)
+    N = length(a)
     for i = 1:(N-1)
-        ai = ustrip.(r[i].position)
+        ai = ustrip.(position(a, i))
         for j = (i+1):N
-            aj = ustrip.(r[j].position)
+            aj = ustrip.(position(a, j))
             rtemp = ai - aj
-            pe +=  potential_energy(rtemp, p)
+            pe += potential_energy(rtemp, p)
         end
     end
     return pe
@@ -25,15 +24,14 @@ function force(a::AtomsBase.Atom, p::EmpiricalPotential)
 end
 
 function force(s::AbstractSystem, p::EmpiricalPotential)
-    r = s.particles
-    n = length(r)
-    f = [ zeros(3) for j = 1:n]
+    n = length(s)
+    f = [zeros(3) for j = 1:n]
     for i = 1:n
-        ai = ustrip.(r[i].position)
+        ai = ustrip.(position(s, i))
         for j = (i+1):n
-            aj = ustrip.(r[j].position)
+            aj = ustrip.(position(s, j))
             rtemp = ai - aj
-            if (norm(rtemp) < 1e-8) 
+            if (norm(rtemp) < 1e-8)
                 continue
             else
                 f[i] += force(rtemp, p)
@@ -48,16 +46,15 @@ function virial(a::AtomsBase.Atom, p::EmpiricalPotential)
     return virial(ustrip.(a.position), p)
 end
 
-function virial(S::AbstractSystem, p::EmpiricalPotential)
-    r = S.particles
-    n = length(r)
+function virial(s::AbstractSystem, p::EmpiricalPotential)
+    n = length(s)
     v = 0.0
     for i = 1:(n-1)
-        ri = ustrip.(r[i].position)
+        ri = ustrip.(position(s, i))
         for j = (i+1):n
-            rj = ustrip.(r[j].position)
+            rj = ustrip.(position(s, j))
             rtemp = ri - rj
-            v +=  virial(rtemp, p)
+            v += virial(rtemp, p)
         end
     end
     return v
@@ -67,14 +64,13 @@ function virial_stress(a::AtomsBase.Atom, p::EmpiricalPotential)
     return virial_stress(ustrip.(a.position), p)
 end
 
-function virial_stress(S::AbstractSystem, p::EmpiricalPotential)
+function virial_stress(s::AbstractSystem, p::EmpiricalPotential)
     v = zeros(Real, 6)
-    r = S.particles
-    n = length(r)
+    n = length(s)
     for i = 1:(n-1)
-        ri = ustrip.(r[i].position)
+        ri = ustrip.(position(s, i))
         for j = (i+1):n
-            rj = ustrip.(r[j].position)
+            rj = ustrip.(position(s, j))
             rtemp = ri - rj
             v += virial_stress(rtemp, p)
         end

--- a/src/PotentialTypes/SNAP/LAMMPS-RECODE/types/runtime_arrays.jl
+++ b/src/PotentialTypes/SNAP/LAMMPS-RECODE/types/runtime_arrays.jl
@@ -32,7 +32,7 @@ struct RuntimeArrays{T}
 end
 
 
-function initialize_runtime_arrays(i::Int, ai::StaticAtom, A::AbstractSystem, snap :: SNAPParams)
+function initialize_runtime_arrays(i::Int, ai::AtomsBase.Atom, A::AbstractSystem, snap :: SNAPParams)
     ind_ij     = SVector{2, Int}[]
     rcutij     = AbstractFloat[] 
     inside  = AbstractFloat[]

--- a/test/lj_test.jl
+++ b/test/lj_test.jl
@@ -6,16 +6,16 @@ using UnitfulAtomic
 
 position = @SVector [1.0, 1.0, 1.0] 
 element  = :Ar
-atom     = StaticAtom(position * 1u"Å", element)
+atom     = AtomsBase.Atom(element, position * 1u"Å")
 lj       = LennardJones(1.0, 1.0)
-@test isa(atom, StaticAtom)
+@test isa(atom, AtomsBase.Atom)
 @test isa(lj, EmpiricalPotential)
 @test isa(potential_energy(atom, lj), AbstractFloat)
 @test isa(force(atom, lj), SVector{3, <:AbstractFloat})
 @test isa(virial(atom, lj), AbstractFloat)
 @test isa(virial_stress(atom, lj), SVector{6, <:AbstractFloat})
 
-atom2    = StaticAtom(0.0*position *1u"Å", element)
+atom2    = AtomsBase.Atom(element, 0.0*position *1u"Å")
 box = [[0.0, 1.0], [0.0, 1.0]]
 system   = FlexibleSystem(box * 1u"Å", [Periodic(), Periodic()], [atom, atom2])
 

--- a/test/snap_test_multi_element.jl
+++ b/test/snap_test_multi_element.jl
@@ -9,7 +9,7 @@ position2 = @SVector [0.5, .50, 0.0]
 position3 = @SVector [0.0, -2.0, 0.0]
 
 
-atoms = [StaticAtom(position1 * 1u"Å", :Ar), StaticAtom(position2 * 1u"Å", :Ar)]#, StaticAtom(position3 * 1u"Å", :Xe)]
+atoms = [AtomsBase.Atom(:Ar, position1 * 1u"Å"), AtomsBase.Atom(:Ar, position2 * 1u"Å")]#, AtomsBase.Atom(:Xe, position3 * 1u"Å")]
 
 box = [[-4.0, 4.0], [-4.0, 4.0]]
 system   = FlexibleSystem(box * 1u"Å", [Periodic(), Periodic()], atoms)

--- a/test/snap_test_single_element.jl
+++ b/test/snap_test_single_element.jl
@@ -11,7 +11,7 @@ for (i,d) in enumerate(0.1:0.1:2.5)
     position2 = @SVector [0.0, d, 0.0]
 
     element  = :Ar
-    atoms = [StaticAtom(position1 * 1u"Å", element), StaticAtom(position2 * 1u"Å", element)]
+    atoms = [AtomsBase.Atom(element, position1 * 1u"Å"), AtomsBase.Atom(element, position2 * 1u"Å")]
 
     box = [[-4.0, 4.0], [-4.0, 4.0]]
     system   = FlexibleSystem(box * 1u"Å", [Periodic(), Periodic()], atoms)


### PR DESCRIPTION
Because the compat for AtomsBase was not specified, the incompatibility with AtomsBase 0.2 prevented InteratomicPotentials and thus Atomisitc from compiling. This is a quick patch to support the new version. Really the only change is that all references to the StaticAtom type (StaticAtom --> AtomsBase.Atom -- qualified because InteratomicPotentials currently still has it's own Atom type). I avoided doing anything else because I know an overhaul is in the works.