### PR TITLE
fix new distance calculation for Dirichlet boundary conditions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteratomicPotentials"
 uuid = "a9efe35a-c65d-452d-b8a8-82646cd5cb04"
 authors = ["Dallas Foster <fostdall@mit.edu>"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/Utilities/nnlist.jl
+++ b/src/Utilities/nnlist.jl
@@ -11,8 +11,12 @@ length(nn::NeighborList) = length(nn.i)
 
 function get_distance(L::SVector{3,<:AbstractFloat}, x::SVector{3,<:AbstractFloat}, y::SVector{3,<:AbstractFloat})
     broadcast(L, x, y) do Li, xi, yi
-        d = mod(xi - yi, Li)
-        2d < Li ? d : d - Li
+        if Li == Inf
+            xi - yi
+        else
+            d = mod(xi - yi, Li)
+            2d < Li ? d : d - Li
+        end
     end
 end
 


### PR DESCRIPTION
These changes to the sign of the distance have uncovered a bug in the SNAP code that assumed the old sign (hence the tests not passing). I have verified that doing `yi - xi` is incorrect for the LJ implementation (particles are attracted to each other way too much and accelerations blow up). I don't know anything about the SNAP code, so I don't want to go poking around changing signs, but I'd suggest that we fix that issue and get the tests passing again in a second commit before merging this PR.