### PR TITLE
add get_rcutoff and get_species functions to API

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -1,6 +1,7 @@
 # The InteratomicPotentials.jl API specification.
 
 export energy_and_force, potential_energy, force, virial, virial_stress
+export get_rcutoff, get_species
 export get_parameters, set_parameters, serialize_parameters, deserialize_parameters
 export get_hyperparameters, set_hyperparameters, serialize_hyperparameters, deserialize_hyperparameters
 
@@ -9,6 +10,9 @@ function potential_energy end
 function force end
 function virial end
 function virial_stress end
+
+function get_rcutoff end
+function get_species end
 
 function get_parameters end
 function set_parameters end

--- a/src/empirical/bm.jl
+++ b/src/empirical/bm.jl
@@ -10,6 +10,9 @@ struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential
     end
 end
 
+get_rcutoff(bm::BornMayer) = bm.rcutoff
+get_species(bm::BornMayer) = bm.species
+
 get_parameters(bm::BornMayer) = Parameter{(:A, :ρ)}((bm.A, bm.ρ))
 set_parameters(bm::BornMayer, p::Parameter{(:A, :ρ)}) = BornMayer(p.A, p.ρ, bm.rcutoff, bm.species)
 

--- a/src/empirical/coulomb.jl
+++ b/src/empirical/coulomb.jl
@@ -10,6 +10,9 @@ struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential
     end
 end
 
+get_rcutoff(c::Coulomb) = c.rcutoff
+get_species(c::Coulomb) = c.species
+
 get_parameters(::Coulomb) = Parameter{}()
 set_parameters(c::Coulomb, ::Parameter{}) = c
 

--- a/src/empirical/lj.jl
+++ b/src/empirical/lj.jl
@@ -10,6 +10,9 @@ struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential
     end
 end
 
+get_rcutoff(lj::LennardJones) = lj.rcutoff
+get_species(lj::LennardJones) = lj.species
+
 get_parameters(lj::LennardJones) = Parameter{(:ϵ, :σ)}((lj.ϵ, lj.σ))
 set_parameters(lj::LennardJones, p::Parameter{(:ϵ, :σ)}) = LennardJones(p.ϵ, p.σ, lj.rcutoff, lj.species)
 

--- a/src/empirical/morse.jl
+++ b/src/empirical/morse.jl
@@ -11,6 +11,9 @@ struct Morse{T<:AbstractFloat} <: EmpiricalPotential
     end
 end
 
+get_rcutoff(m::Morse) = m.rcutoff
+get_species(m::Morse) = m.species
+
 get_parameters(m::Morse) = Parameter{(:D, :α, :σ)}((m.D, m.α, m.σ))
 set_parameters(m::Morse, p::Parameter{(:D, :α, :σ)}) = Morse(p.D, p.α, p.σ, m.rcutoff, m.species)
 

--- a/src/empirical/zbl.jl
+++ b/src/empirical/zbl.jl
@@ -14,6 +14,9 @@ struct ZBL{T<:AbstractFloat} <: EmpiricalPotential
     end
 end
 
+get_rcutoff(zbl::ZBL) = zbl.rcutoff
+get_species(zbl::ZBL) = zbl.species
+
 get_parameters(::ZBL) = Parameter{}()
 set_parameters(zbl::ZBL, ::Parameter{}) = zbl
 

--- a/src/mixed/linear_combination_potential.jl
+++ b/src/mixed/linear_combination_potential.jl
@@ -15,7 +15,8 @@ Base.:/(p::ArbitraryPotential, a::Real) = (1.0 / a) * p
 Base.:+(mp1::LinearCombinationPotential, mp2::LinearCombinationPotential) = LinearCombinationPotential(vcat(mp1.potentials, mp2.potentials), vcat(mp1.coefficients, mp2.coefficients))
 Base.:*(a::Real, mp::LinearCombinationPotential) = LinearCombinationPotential(mp.potentials, a * mp.coefficients)
 
-_apply_linear_combination(f::Function, sys::AbstractSystem, mp::LinearCombinationPotential) = sum(c * f(sys, p) for (p, c) in zip(mp.potentials, mp.coefficients))
+get_rcutoff(mp::LinearCombinationPotential) = maximum(get_rcutoff, mp.potentials)
+get_species(::LinearCombinationPotential) = missing
 
 function energy_and_force(sys::AbstractSystem, mp::LinearCombinationPotential)
     efs = [energy_and_force(sys, p) for p in mp.potentials]
@@ -23,6 +24,8 @@ function energy_and_force(sys::AbstractSystem, mp::LinearCombinationPotential)
     f = sum(c * ef.f for (ef, c) in zip(efs, mp.coefficients))
     (; e, f)
 end
+
+_apply_linear_combination(f::Function, sys::AbstractSystem, mp::LinearCombinationPotential) = sum(c * f(sys, p) for (p, c) in zip(mp.potentials, mp.coefficients))
 
 potential_energy(sys::AbstractSystem, mp::LinearCombinationPotential) = _apply_linear_combination(potential_energy, sys, mp)
 force(sys::AbstractSystem, mp::LinearCombinationPotential) = _apply_linear_combination(force, sys, mp)

--- a/src/types/arbitrary_potential.jl
+++ b/src/types/arbitrary_potential.jl
@@ -2,6 +2,9 @@
 # InteratomicPotentials API default generic implmentations
 ################################################################################
 
+get_rcutoff(::ArbitraryPotential) = Inf
+get_species(::ArbitraryPotential) = missing
+
 potential_energy(A::AbstractSystem, p::ArbitraryPotential) = energy_and_force(A, p).e
 force(A::AbstractSystem, p::ArbitraryPotential) = energy_and_force(A, p).f
 virial(A::AbstractSystem, p::ArbitraryPotential) = sum(virial_stress(A, p)[1:3])

--- a/src/types/empirical_potential.jl
+++ b/src/types/empirical_potential.jl
@@ -17,14 +17,13 @@ export LennardJones, BornMayer, Coulomb, ZBL, Morse
 force(r::SVector{3}, p::EmpiricalPotential) = force(norm(r), r, p)
 
 function energy_and_force(A::AbstractSystem, p::EmpiricalPotential)
-    nnlist = neighborlist(A, p.rcutoff)
+    nnlist = neighborlist(A, get_rcutoff(p))
 
     e = 0.0
     f = fill(SVector{3}(zeros(3)), length(A))
     for ii in 1:length(A)
         for (jj, r, R) in zip(nnlist.j[ii], nnlist.r[ii], nnlist.R[ii])
-            species = unique([atomic_symbol(A, ii), atomic_symbol(A, jj)])
-            if (intersect(species, p.species) == species)
+            if (ismissing(get_species(p)) || (atomic_symbol(A, ii), atomic_symbol(A, jj)) ⊆ get_species(p))
                 e += potential_energy(R, p)
                 fo = force(R, r, p)
                 f[ii] = f[ii] + fo
@@ -36,7 +35,7 @@ function energy_and_force(A::AbstractSystem, p::EmpiricalPotential)
 end
 
 function virial_stress(A::AbstractSystem, p::EmpiricalPotential)
-    nnlist = neighborlist(A, p.rcutoff)
+    nnlist = neighborlist(A, get_rcutoff(p))
 
     v = @SVector zeros(6)
     for ii in 1:length(A)

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -1,6 +1,5 @@
 struct MockArbitraryPotential <: ArbitraryPotential
     seed::Float64
-    species::Tuple
 end
 function InteratomicPotentials.energy_and_force(A::AbstractSystem, p::MockArbitraryPotential)
     (
@@ -17,6 +16,8 @@ struct MockEmpiricalPotential <: EmpiricalPotential
     rcutoff::Float64
     species::Tuple
 end
+InteratomicPotentials.get_rcutoff(p::MockEmpiricalPotential) = p.rcutoff
+InteratomicPotentials.get_species(p::MockEmpiricalPotential) = p.species
 function InteratomicPotentials.potential_energy(R::AbstractFloat, p::MockEmpiricalPotential)
     R^2 * p.seed
 end

--- a/test/unit/empirical/bm.jl
+++ b/test/unit/empirical/bm.jl
@@ -8,8 +8,8 @@
     @test p isa EmpiricalPotential
     @test p.A == austrip(A)
     @test p.ρ == austrip(ρ)
-    @test p.rcutoff == austrip(rcutoff)
-    @test p.species == (:Ar, :H)
+    @test get_rcutoff(p) == austrip(rcutoff)
+    @test get_species(p) == (:Ar, :H)
 
     @test get_parameters(p) == (; A=austrip(A), ρ=austrip(ρ))
     @test set_parameters(p, (; A=2.0, ρ=3.0)) == BornMayer(2.0, 3.0, austrip(rcutoff), species)

--- a/test/unit/empirical/coulomb.jl
+++ b/test/unit/empirical/coulomb.jl
@@ -8,8 +8,8 @@
     @test p isa EmpiricalPotential
     @test p.q₁ == austrip(q₁)
     @test p.q₂ == austrip(q₂)
-    @test p.rcutoff == austrip(rcutoff)
-    @test p.species == (:Ar, :H)
+    @test get_rcutoff(p) == austrip(rcutoff)
+    @test get_species(p) == (:Ar, :H)
 
     @test get_parameters(p) == (;)
     @test set_parameters(p, (;)) === p

--- a/test/unit/empirical/lj.jl
+++ b/test/unit/empirical/lj.jl
@@ -8,8 +8,8 @@
     @test p isa EmpiricalPotential
     @test p.ϵ == austrip(ϵ)
     @test p.σ == austrip(σ)
-    @test p.rcutoff == austrip(rcutoff)
-    @test p.species == (:Ar, :H)
+    @test get_rcutoff(p) == austrip(rcutoff)
+    @test get_species(p) == (:Ar, :H)
 
     @test get_parameters(p) == (; ϵ=austrip(ϵ), σ=austrip(σ))
     @test set_parameters(p, (; ϵ=2.0, σ=3.0)) == LennardJones(2.0, 3.0, austrip(rcutoff), species)

--- a/test/unit/empirical/morse.jl
+++ b/test/unit/empirical/morse.jl
@@ -10,8 +10,8 @@
     @test p.D == austrip(D)
     @test p.α == α
     @test p.σ == austrip(σ)
-    @test p.rcutoff == austrip(rcutoff)
-    @test p.species == (:Ar, :H)
+    @test get_rcutoff(p) == austrip(rcutoff)
+    @test get_species(p) == (:Ar, :H)
 
     @test get_parameters(p) == (; D=austrip(D), α, σ=austrip(σ))
     @test set_parameters(p, (; D=2.0, α=1.0, σ=3.0)) == Morse(2.0, 1.0, 3.0, austrip(rcutoff), species)

--- a/test/unit/empirical/zbl.jl
+++ b/test/unit/empirical/zbl.jl
@@ -10,8 +10,8 @@
     @test p.Z₁ == Z₁
     @test p.Z₂ == Z₂
     @test p.e == austrip(e)
-    @test p.rcutoff == austrip(rcutoff)
-    @test p.species == (:Ar, :H)
+    @test get_rcutoff(p) == austrip(rcutoff)
+    @test get_species(p) == (:Ar, :H)
 
     @test get_parameters(p) == (;)
     @test set_parameters(p, (;)) === p

--- a/test/unit/mixed/linear_combination_potential.jl
+++ b/test/unit/mixed/linear_combination_potential.jl
@@ -8,8 +8,8 @@
     box = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]u"bohr"
     system = periodic_system(atoms, box)
 
-    p1 = MockArbitraryPotential(1.0, (:Ar, :H))
-    p2 = MockArbitraryPotential(2.0, (:Ar, :H))
+    p1 = MockEmpiricalPotential(1.0, 1.0, (:Ar,))
+    p2 = MockArbitraryPotential(2.0)
     mixed_potentials = [
         +p1,
         -p1,
@@ -21,56 +21,69 @@
         3.0 * (p1 + p2)
     ]
 
+    true_rcutoffs = [
+        1.0,
+        1.0,
+        Inf,
+        Inf,
+        1.0,
+        Inf,
+        Inf,
+        Inf
+    ]
     true_energies = [
-        1.0,
-        -1.0,
-        3.0,
-        -1.0,
-        2.0,
-        1.0,
-        0.0,
-        9.0
-    ]u"hartree"
+        potential_energy(system, p1),
+        -potential_energy(system, p1),
+        potential_energy(system, p1) + potential_energy(system, p2),
+        potential_energy(system, p1) - potential_energy(system, p2),
+        2 * potential_energy(system, p1),
+        potential_energy(system, p2) / 2,
+        2 * potential_energy(system, p1) - potential_energy(system, p2),
+        3 * (potential_energy(system, p1) + potential_energy(system, p2))
+    ]
     true_forces = [
-        SVector{3}.([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0], [2.0, 3.0, 4.0], [2.0, 3.0, 4.0]]),
-        SVector{3}.([[-2.0, -3.0, -4.0], [-2.0, -3.0, -4.0], [-2.0, -3.0, -4.0], [-2.0, -3.0, -4.0]]),
-        SVector{3}.([[5.0, 7.0, 9.0], [5.0, 7.0, 9.0], [5.0, 7.0, 9.0], [5.0, 7.0, 9.0]]),
-        SVector{3}.([[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]]),
-        SVector{3}.([[4.0, 6.0, 8.0], [4.0, 6.0, 8.0], [4.0, 6.0, 8.0], [4.0, 6.0, 8.0]]),
-        SVector{3}.([[1.5, 2.0, 2.5], [1.5, 2.0, 2.5], [1.5, 2.0, 2.5], [1.5, 2.0, 2.5]]),
-        SVector{3}.([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
-        SVector{3}.([[15.0, 21.0, 27.0], [15.0, 21.0, 27.0], [15.0, 21.0, 27.0], [15.0, 21.0, 27.0]])
-    ]u"hartree/bohr"
+        force(system, p1),
+        -force(system, p1),
+        force(system, p1) + force(system, p2),
+        force(system, p1) - force(system, p2),
+        2 * force(system, p1),
+        force(system, p2) / 2,
+        2 * force(system, p1) - force(system, p2),
+        3 * (force(system, p1) + force(system, p2))
+    ]
     true_virials = [
-        -3.0,
-        3.0,
-        -3.0,
-        -3.0,
-        -6.0,
-        0.0,
-        -6.0,
-        -9.0
-    ]u"hartree"
-    true_virial_stresses = SVector{6}.([
-        [0.0, -1.0, -2.0, -3.0, -4.0, -5.0],
-        [-0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
-        [1.0, -1.0, -3.0, -5.0, -7.0, -9.0],
-        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
-        [0.0, -2.0, -4.0, -6.0, -8.0, -10.0],
-        [0.5, 0.0, -0.5, -1.0, -1.5, -2.0],
-        [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0],
-        [3.0, -3.0, -9.0, -15.0, -21.0, -27.0]
-    ])u"hartree"
+        virial(system, p1),
+        -virial(system, p1),
+        virial(system, p1) + virial(system, p2),
+        virial(system, p1) - virial(system, p2),
+        2 * virial(system, p1),
+        virial(system, p2) / 2,
+        2 * virial(system, p1) - virial(system, p2),
+        3 * (virial(system, p1) + virial(system, p2))
+    ]
+    true_virial_stresses = [
+        virial_stress(system, p1),
+        -virial_stress(system, p1),
+        virial_stress(system, p1) + virial_stress(system, p2),
+        virial_stress(system, p1) - virial_stress(system, p2),
+        2 * virial_stress(system, p1),
+        virial_stress(system, p2) / 2,
+        2 * virial_stress(system, p1) - virial_stress(system, p2),
+        3 * (virial_stress(system, p1) + virial_stress(system, p2))
+    ]
 
-    for (p, te, tf, tv, tvs) in zip(mixed_potentials, true_energies, true_forces, true_virials, true_virial_stresses)
+    for (p, trc, te, tf, tv, tvs) in zip(mixed_potentials, true_rcutoffs, true_energies, true_forces, true_virials, true_virial_stresses)
         @test p isa MixedPotential
+
+        @test get_rcutoff(p) == trc
+        @test ismissing(get_species(p))
+
+        @test energy_and_force(system, p).e == te
+        @test energy_and_force(system, p).f == tf
 
         @test potential_energy(system, p) == te
         @test force(system, p) == tf
         @test virial(system, p) == tv
         @test virial_stress(system, p) == tvs
-
-        @test energy_and_force(system, p).e == te
-        @test energy_and_force(system, p).f == tf
     end
 end

--- a/test/unit/types/arbitrary_potential.jl
+++ b/test/unit/types/arbitrary_potential.jl
@@ -8,7 +8,10 @@
     box = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]u"bohr"
     system = periodic_system(atoms, box)
 
-    p = MockArbitraryPotential(0.0, (:Ar, :H))
+    p = MockArbitraryPotential(0.0)
+
+    @test get_rcutoff(p) == Inf
+    @test ismissing(get_species(p))
 
     @test potential_energy(system, p) == 0.0u"hartree"
     @test force(system, p) == fill((@SVector[1.0, 2.0, 3.0])u"hartree/bohr", 4)


### PR DESCRIPTION
This PR adds two new field accessor functions to the API: `get_rcutoff` and `get_species`. This allows us to avoid using direct field access in the aggregation functions and will be very important for when we externalize the neighbor list interface. New implementations default to `Inf` and `missing` respectively. The `LinearCombinationPotential` has `rcutoff` which is the `maximum` of its subpotentials. This choice seems sensible right now but it could potentially be revisited when we rework the neighbor list abstraction in version 0.3.