### PR TITLE
Refine parameter interface part 2

### DIFF
--- a/src/InteratomicPotentials.jl
+++ b/src/InteratomicPotentials.jl
@@ -9,9 +9,6 @@ using UnitfulAtomic
 using Distances
 using NearestNeighbors
 
-import Base.NamedTuple as Parameter
-export Parameter
-
 include("unit_convention.jl")
 include("constants.jl")
 include("nnlist.jl")

--- a/src/empirical/bm.jl
+++ b/src/empirical/bm.jl
@@ -1,5 +1,5 @@
 ##############################   Born-Mayer  ###################################
-struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential
+struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:A, :ρ)},Parameter{(:rcutoff,)}}
     A::T
     ρ::T
     rcutoff::T
@@ -8,19 +8,10 @@ struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential
         A, ρ, rcutoff = promote(austrip(A), austrip(ρ), austrip(rcutoff))
         new{typeof(rcutoff)}(A, ρ, rcutoff, Tuple(species))
     end
+    function BornMayer{T}(; A::T, ρ::T, rcutoff::T, species::Tuple) where {T}
+        new{T}(A, ρ, rcutoff, species)
+    end
 end
-
-get_parameters(bm::BornMayer) = Parameter{(:A, :ρ)}((bm.A, bm.ρ))
-set_parameters(bm::BornMayer, p::Parameter{(:A, :ρ)}) = BornMayer(p.A, p.ρ, bm.rcutoff, bm.species)
-
-serialize_parameters(bm::BornMayer) = collect(get_parameters(bm))
-deserialize_parameters(bm::BornMayer, p::AbstractVector) = set_parameters(bm, Parameter{(:A, :ρ)}(p))
-
-get_hyperparameters(bm::BornMayer) = Parameter{(:rcutoff,)}((bm.rcutoff,))
-set_hyperparameters(bm::BornMayer, p::Parameter{(:rcutoff,)}) = BornMayer(bm.A, bm.ρ, p.rcutoff, bm.species)
-
-serialize_hyperparameters(bm::BornMayer) = collect(get_hyperparameters(bm))
-deserialize_hyperparameters(bm::BornMayer, p::AbstractVector) = set_hyperparameters(bm, Parameter{(:rcutoff,)}(p))
 
 potential_energy(R::AbstractFloat, bm::BornMayer) = bm.A * exp(-R / bm.ρ)
 force(R::AbstractFloat, r::SVector{3}, bm::BornMayer) = (bm.A * exp(-R / bm.ρ) / (bm.ρ * R))r

--- a/src/empirical/bm.jl
+++ b/src/empirical/bm.jl
@@ -1,5 +1,5 @@
 ##############################   Born-Mayer  ###################################
-struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:A, :ρ)},Parameter{(:rcutoff,)}}
+struct BornMayer{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{(:A, :ρ)},NamedTuple{(:rcutoff,)}}
     A::T
     ρ::T
     rcutoff::T

--- a/src/empirical/coulomb.jl
+++ b/src/empirical/coulomb.jl
@@ -1,5 +1,5 @@
 ##############################   Coulomb  ###################################
-struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential
+struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential{Parameter{()},Parameter{(:rcutoff,)}}
     q₁::T
     q₂::T
     rcutoff::T
@@ -8,19 +8,10 @@ struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential
         q₁, q₂, rcutoff = promote(austrip(q₁), austrip(q₂), austrip(rcutoff))
         new{typeof(rcutoff)}(q₁, q₂, rcutoff, Tuple(species))
     end
+    function Coulomb{T}(; q₁::T, q₂::T, rcutoff::T, species::Tuple) where {T}
+        new{T}(q₁, q₂, rcutoff, species)
+    end
 end
-
-get_parameters(::Coulomb) = Parameter{}()
-set_parameters(c::Coulomb, ::Parameter{}) = c
-
-serialize_parameters(c::Coulomb) = collect(get_parameters(c))
-deserialize_parameters(c::Coulomb, p::AbstractVector) = set_parameters(c, Parameter{}(p))
-
-get_hyperparameters(c::Coulomb) = Parameter{(:rcutoff,)}((c.rcutoff,))
-set_hyperparameters(c::Coulomb, p::Parameter{(:rcutoff,)}) = Coulomb(c.q₁, c.q₂, p.rcutoff, c.species)
-
-serialize_hyperparameters(c::Coulomb) = collect(get_hyperparameters(c))
-deserialize_hyperparameters(c::Coulomb, p::AbstractVector) = set_hyperparameters(c, Parameter{(:rcutoff,)}(p))
 
 potential_energy(R::AbstractFloat, c::Coulomb) = kₑ * c.q₁ * c.q₂ / R
 force(R::AbstractFloat, r::SVector{3}, c::Coulomb) = (kₑ * c.q₁ * c.q₂ / R^3)r

--- a/src/empirical/coulomb.jl
+++ b/src/empirical/coulomb.jl
@@ -1,5 +1,5 @@
 ##############################   Coulomb  ###################################
-struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential{Parameter{()},Parameter{(:rcutoff,)}}
+struct Coulomb{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{()},NamedTuple{(:rcutoff,)}}
     q₁::T
     q₂::T
     rcutoff::T

--- a/src/empirical/lj.jl
+++ b/src/empirical/lj.jl
@@ -1,5 +1,5 @@
 ############################## Lennard Jones ###################################
-struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential
+struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:ϵ, :σ)},Parameter{(:rcutoff,)}}
     ϵ::T
     σ::T
     rcutoff::T
@@ -8,19 +8,10 @@ struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential
         ϵ, σ, rcutoff = promote(austrip(ϵ), austrip(σ), austrip(rcutoff))
         new{typeof(rcutoff)}(ϵ, σ, rcutoff, Tuple(species))
     end
+    function LennardJones{T}(; ϵ::T, σ::T, rcutoff::T, species::Tuple) where {T}
+        new{T}(ϵ, σ, rcutoff, species)
+    end
 end
-
-get_parameters(lj::LennardJones) = Parameter{(:ϵ, :σ)}((lj.ϵ, lj.σ))
-set_parameters(lj::LennardJones, p::Parameter{(:ϵ, :σ)}) = LennardJones(p.ϵ, p.σ, lj.rcutoff, lj.species)
-
-serialize_parameters(lj::LennardJones) = collect(get_parameters(lj))
-deserialize_parameters(lj::LennardJones, p::AbstractVector) = set_parameters(lj, Parameter{(:ϵ, :σ)}(p))
-
-get_hyperparameters(lj::LennardJones) = Parameter{(:rcutoff,)}((lj.rcutoff,))
-set_hyperparameters(lj::LennardJones, p::Parameter{(:rcutoff,)}) = LennardJones(lj.ϵ, lj.σ, p.rcutoff, lj.species)
-
-serialize_hyperparameters(lj::LennardJones) = collect(get_hyperparameters(lj))
-deserialize_hyperparameters(lj::LennardJones, p::AbstractVector) = set_hyperparameters(lj, Parameter{(:rcutoff,)}(p))
 
 potential_energy(R::AbstractFloat, lj::LennardJones) = 4lj.ϵ * ((lj.σ / R)^12 - (lj.σ / R)^6)
 force(R::AbstractFloat, r::SVector{3}, lj::LennardJones) = (24lj.ϵ * (2(lj.σ / R)^12 - (lj.σ / R)^6) / R^2)r

--- a/src/empirical/lj.jl
+++ b/src/empirical/lj.jl
@@ -1,5 +1,5 @@
 ############################## Lennard Jones ###################################
-struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:ϵ, :σ)},Parameter{(:rcutoff,)}}
+struct LennardJones{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{(:ϵ, :σ)},NamedTuple{(:rcutoff,)}}
     ϵ::T
     σ::T
     rcutoff::T

--- a/src/empirical/morse.jl
+++ b/src/empirical/morse.jl
@@ -1,5 +1,5 @@
 ############################## Morse ###################################
-struct Morse{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:D, :α, :σ)},Parameter{(:rcutoff,)}}
+struct Morse{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{(:D, :α, :σ)},NamedTuple{(:rcutoff,)}}
     D::T
     α::T
     σ::T

--- a/src/empirical/morse.jl
+++ b/src/empirical/morse.jl
@@ -1,5 +1,5 @@
 ############################## Morse ###################################
-struct Morse{T<:AbstractFloat} <: EmpiricalPotential
+struct Morse{T<:AbstractFloat} <: EmpiricalPotential{Parameter{(:D, :α, :σ)},Parameter{(:rcutoff,)}}
     D::T
     α::T
     σ::T
@@ -9,19 +9,10 @@ struct Morse{T<:AbstractFloat} <: EmpiricalPotential
         D, α, σ, rcutoff = promote(austrip(D), α, austrip(σ), austrip(rcutoff))
         new{typeof(rcutoff)}(D, α, σ, rcutoff, Tuple(species))
     end
+    function Morse{T}(; D::T, α::T, σ::T, rcutoff::T, species::Tuple) where {T}
+        new{T}(D, α, σ, rcutoff, species)
+    end
 end
-
-get_parameters(m::Morse) = Parameter{(:D, :α, :σ)}((m.D, m.α, m.σ))
-set_parameters(m::Morse, p::Parameter{(:D, :α, :σ)}) = Morse(p.D, p.α, p.σ, m.rcutoff, m.species)
-
-serialize_parameters(m::Morse) = collect(get_parameters(m))
-deserialize_parameters(m::Morse, p::AbstractVector) = set_parameters(m, Parameter{(:D, :α, :σ)}(p))
-
-get_hyperparameters(m::Morse) = Parameter{(:rcutoff,)}((m.rcutoff,))
-set_hyperparameters(m::Morse, p::Parameter{(:rcutoff,)}) = Morse(m.D, m.α, m.σ, p.rcutoff, m.species)
-
-serialize_hyperparameters(m::Morse) = collect(get_hyperparameters(m))
-deserialize_hyperparameters(m::Morse, p::AbstractVector) = set_hyperparameters(m, Parameter{(:rcutoff,)}(p))
 
 _morse_exp(R::AbstractFloat, m::Morse) = exp(-m.α * (R - m.σ))
 

--- a/src/empirical/zbl.jl
+++ b/src/empirical/zbl.jl
@@ -2,7 +2,7 @@
 ## employed within LAMMPS.
 
 ############################## ZBL ###################################
-struct ZBL{T<:AbstractFloat} <: EmpiricalPotential
+struct ZBL{T<:AbstractFloat} <: EmpiricalPotential{Parameter{()},Parameter{(:rcutoff,)}}
     Z₁::Int
     Z₂::Int
     e::T
@@ -12,19 +12,10 @@ struct ZBL{T<:AbstractFloat} <: EmpiricalPotential
         Z₁, Z₂, e, rcutoff = promote(Z₁, Z₂, austrip(e), austrip(rcutoff))
         new{typeof(rcutoff)}(Z₁, Z₂, e, rcutoff, Tuple(species))
     end
+    function ZBL{T}(; Z₁::Int, Z₂::Int, e::T, rcutoff::T, species::Tuple) where {T}
+        new{T}(Z₁, Z₂, e, rcutoff, species)
+    end
 end
-
-get_parameters(::ZBL) = Parameter{}()
-set_parameters(zbl::ZBL, ::Parameter{}) = zbl
-
-serialize_parameters(zbl::ZBL) = collect(get_parameters(zbl))
-deserialize_parameters(zbl::ZBL, p::AbstractVector) = set_parameters(zbl, Parameter{}(p))
-
-get_hyperparameters(zbl::ZBL) = Parameter{(:rcutoff,)}((zbl.rcutoff,))
-set_hyperparameters(zbl::ZBL, p::Parameter{(:rcutoff,)}) = ZBL(zbl.Z₁, zbl.Z₂, zbl.e, p.rcutoff, zbl.species)
-
-serialize_hyperparameters(zbl::ZBL) = collect(get_hyperparameters(zbl))
-deserialize_hyperparameters(zbl::ZBL, p::AbstractVector) = set_hyperparameters(zbl, Parameter{(:rcutoff,)}(p))
 
 const _ϕ_coeffs = [0.18175, 0.50986, 0.28022, 0.02817]
 const _ϕ_exps = [3.19980, 0.94229, 0.40290, 0.20162]

--- a/src/empirical/zbl.jl
+++ b/src/empirical/zbl.jl
@@ -2,7 +2,7 @@
 ## employed within LAMMPS.
 
 ############################## ZBL ###################################
-struct ZBL{T<:AbstractFloat} <: EmpiricalPotential{Parameter{()},Parameter{(:rcutoff,)}}
+struct ZBL{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{()},NamedTuple{(:rcutoff,)}}
     Z₁::Int
     Z₂::Int
     e::T

--- a/src/mixed/linear_combination_potential.jl
+++ b/src/mixed/linear_combination_potential.jl
@@ -1,16 +1,16 @@
 struct LinearCombinationPotential <: MixedPotential
-    potentials::Vector{ArbitraryPotential}
+    potentials::Vector{AbstractPotential}
     coefficients::Vector{AbstractFloat}
 end
-LinearCombinationPotential(p::ArbitraryPotential) = LinearCombinationPotential([p], [1])
+LinearCombinationPotential(p::AbstractPotential) = LinearCombinationPotential([p], [1])
 LinearCombinationPotential(p::LinearCombinationPotential) = p
 
-Base.:+(p::ArbitraryPotential) = +1 * p
-Base.:-(p::ArbitraryPotential) = -1 * p
-Base.:+(p1::ArbitraryPotential, p2::ArbitraryPotential) = LinearCombinationPotential(p1) + LinearCombinationPotential(p2)
-Base.:-(p1::ArbitraryPotential, p2::ArbitraryPotential) = p1 + -p2
-Base.:*(a::Real, p::ArbitraryPotential) = a * LinearCombinationPotential(p)
-Base.:/(p::ArbitraryPotential, a::Real) = (1.0 / a) * p
+Base.:+(p::AbstractPotential) = +1 * p
+Base.:-(p::AbstractPotential) = -1 * p
+Base.:+(p1::AbstractPotential, p2::AbstractPotential) = LinearCombinationPotential(p1) + LinearCombinationPotential(p2)
+Base.:-(p1::AbstractPotential, p2::AbstractPotential) = p1 + -p2
+Base.:*(a::Real, p::AbstractPotential) = a * LinearCombinationPotential(p)
+Base.:/(p::AbstractPotential, a::Real) = (1.0 / a) * p
 
 Base.:+(mp1::LinearCombinationPotential, mp2::LinearCombinationPotential) = LinearCombinationPotential(vcat(mp1.potentials, mp2.potentials), vcat(mp1.coefficients, mp2.coefficients))
 Base.:*(a::Real, mp::LinearCombinationPotential) = LinearCombinationPotential(mp.potentials, a * mp.coefficients)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 # The abstract types provided by InteratomicPotentials.jl
 
-export ArbitraryPotential, EmpiricalPotential, MixedPotential
+export ArbitraryPotential, NonTrainablePotential, TrainablePotential, EmpiricalPotential, MixedPotential
 
 ################################################################################
 # InteratomicPotentials API default generic implmentations
@@ -9,9 +9,21 @@ abstract type ArbitraryPotential end
 include("types/arbitrary_potential.jl")
 
 ################################################################################
+# Non-Trainable Potentials
+################################################################################
+abstract type NonTrainablePotential <: ArbitraryPotential end
+include("types/non_trainable_potential.jl")
+
+################################################################################
+# Trainable Potentials
+################################################################################
+abstract type TrainablePotential{P<:Parameter,HP<:Parameter} <: ArbitraryPotential end
+include("types/trainable_potential.jl")
+
+################################################################################
 # Empirical Potentials
 ################################################################################
-abstract type EmpiricalPotential <: ArbitraryPotential end
+abstract type EmpiricalPotential{P<:Parameter,HP<:Parameter} <: TrainablePotential{P,HP} end
 include("types/empirical_potential.jl")
 
 ################################################################################

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,33 +1,33 @@
 # The abstract types provided by InteratomicPotentials.jl
 
-export ArbitraryPotential, NonTrainablePotential, TrainablePotential, EmpiricalPotential, MixedPotential
+export AbstractPotential, NonTrainablePotential, TrainablePotential, EmpiricalPotential, MixedPotential
 
 ################################################################################
-# InteratomicPotentials API default generic implmentations
+# Abstract Supertype of all Potentials
 ################################################################################
-abstract type ArbitraryPotential end
-include("types/arbitrary_potential.jl")
+abstract type AbstractPotential end
+include("types/abstract_potential.jl")
 
 ################################################################################
 # Non-Trainable Potentials
 ################################################################################
-abstract type NonTrainablePotential <: ArbitraryPotential end
+abstract type NonTrainablePotential <: AbstractPotential end
 include("types/non_trainable_potential.jl")
 
 ################################################################################
 # Trainable Potentials
 ################################################################################
-abstract type TrainablePotential{P<:Parameter,HP<:Parameter} <: ArbitraryPotential end
+abstract type TrainablePotential{P<:NamedTuple,HP<:NamedTuple} <: AbstractPotential end
 include("types/trainable_potential.jl")
 
 ################################################################################
 # Empirical Potentials
 ################################################################################
-abstract type EmpiricalPotential{P<:Parameter,HP<:Parameter} <: TrainablePotential{P,HP} end
+abstract type EmpiricalPotential{P<:NamedTuple,HP<:NamedTuple} <: TrainablePotential{P,HP} end
 include("types/empirical_potential.jl")
 
 ################################################################################
 # Mixed Potentials
 ################################################################################
-abstract type MixedPotential <: ArbitraryPotential end
+abstract type MixedPotential <: AbstractPotential end
 include("types/mixed_potential.jl")

--- a/src/types/abstract_potential.jl
+++ b/src/types/abstract_potential.jl
@@ -1,0 +1,7 @@
+################################################################################
+# InteratomicPotentials API default implementations
+################################################################################
+
+potential_energy(A::AbstractSystem, p::AbstractPotential) = energy_and_force(A, p).e
+force(A::AbstractSystem, p::AbstractPotential) = energy_and_force(A, p).f
+virial(A::AbstractSystem, p::AbstractPotential) = sum(virial_stress(A, p)[1:3])

--- a/src/types/arbitrary_potential.jl
+++ b/src/types/arbitrary_potential.jl
@@ -1,7 +1,0 @@
-################################################################################
-# InteratomicPotentials API default generic implmentations
-################################################################################
-
-potential_energy(A::AbstractSystem, p::ArbitraryPotential) = energy_and_force(A, p).e
-force(A::AbstractSystem, p::ArbitraryPotential) = energy_and_force(A, p).f
-virial(A::AbstractSystem, p::ArbitraryPotential) = sum(virial_stress(A, p)[1:3])

--- a/src/types/empirical_potential.jl
+++ b/src/types/empirical_potential.jl
@@ -11,7 +11,7 @@ include("../empirical/morse.jl")
 export LennardJones, BornMayer, Coulomb, ZBL, Morse
 
 ################################################################################
-# InteratomicPotentials API implmentations for empirical potentials
+# InteratomicPotentials API implementations for empirical potentials
 ################################################################################
 
 force(r::SVector{3}, p::EmpiricalPotential) = force(norm(r), r, p)

--- a/src/types/non_trainable_potential.jl
+++ b/src/types/non_trainable_potential.jl
@@ -1,0 +1,15 @@
+################################################################################
+# InteratomicPotentials API default implmentations for non-trainable potentials
+################################################################################
+
+get_parameters(::NonTrainablePotential) = Parameter{()}()
+set_parameters(p::NonTrainablePotential, ::Parameter{()}) = p
+
+serialize_parameters(::NonTrainablePotential) = []
+deserialize_parameters(::NonTrainablePotential, ::AbstractVector) = p
+
+get_hyperparameters(::NonTrainablePotential) = Parameter{()}()
+set_hyperparameters(::NonTrainablePotential, ::Parameter{()}) = p
+
+serialize_hyperparameters(::NonTrainablePotential) = []
+deserialize_hyperparameters(::NonTrainablePotential, ::AbstractVector) = p

--- a/src/types/non_trainable_potential.jl
+++ b/src/types/non_trainable_potential.jl
@@ -1,15 +1,15 @@
 ################################################################################
-# InteratomicPotentials API default implmentations for non-trainable potentials
+# InteratomicPotentials API default implementations for non-trainable potentials
 ################################################################################
 
-get_parameters(::NonTrainablePotential) = Parameter{()}()
-set_parameters(p::NonTrainablePotential, ::Parameter{()}) = p
+get_parameters(::NonTrainablePotential) = NamedTuple{()}()
+set_parameters(p::NonTrainablePotential, ::NamedTuple{()}) = p
 
 serialize_parameters(::NonTrainablePotential) = []
 deserialize_parameters(::NonTrainablePotential, ::AbstractVector) = p
 
-get_hyperparameters(::NonTrainablePotential) = Parameter{()}()
-set_hyperparameters(::NonTrainablePotential, ::Parameter{()}) = p
+get_hyperparameters(::NonTrainablePotential) = NamedTuple{()}()
+set_hyperparameters(::NonTrainablePotential, ::NamedTuple{()}) = p
 
 serialize_hyperparameters(::NonTrainablePotential) = []
 deserialize_hyperparameters(::NonTrainablePotential, ::AbstractVector) = p

--- a/src/types/trainable_potential.jl
+++ b/src/types/trainable_potential.jl
@@ -1,0 +1,31 @@
+################################################################################
+# InteratomicPotentials API implmentations for trainable potentials
+################################################################################
+
+function get_parameters(tp::TrainablePotential{P}) where {names,P<:Parameter{names}}
+    P((getproperty(tp, name) for name ∈ names))
+end
+function set_parameters(tp::TP, p::P) where {P,TP<:TrainablePotential{P}}
+    TP(; (name => getproperty(tp, name) for name ∈ propertynames(tp))..., p...)
+end
+
+function serialize_parameters(tp::TrainablePotential)
+    collect(get_parameters(tp))
+end
+function deserialize_parameters(tp::TrainablePotential{P}, p::AbstractVector) where {P}
+    set_parameters(tp, P(p))
+end
+
+function get_hyperparameters(tp::TrainablePotential{P,HP}) where {P,names,HP<:Parameter{names}}
+    HP((getproperty(tp, name) for name ∈ names))
+end
+function set_hyperparameters(tp::TP, p::HP) where {P,HP,TP<:TrainablePotential{P,HP}}
+    TP(; (name => getproperty(tp, name) for name ∈ propertynames(tp))..., p...)
+end
+
+function serialize_hyperparameters(tp::TrainablePotential)
+    collect(get_hyperparameters(tp))
+end
+function deserialize_hyperparameters(tp::TrainablePotential{P,HP}, p::AbstractVector) where {P,HP}
+    set_hyperparameters(tp, HP(p))
+end

--- a/src/types/trainable_potential.jl
+++ b/src/types/trainable_potential.jl
@@ -1,8 +1,8 @@
 ################################################################################
-# InteratomicPotentials API implmentations for trainable potentials
+# InteratomicPotentials API implementations for trainable potentials
 ################################################################################
 
-function get_parameters(tp::TrainablePotential{P}) where {names,P<:Parameter{names}}
+function get_parameters(tp::TrainablePotential{P}) where {names,P<:NamedTuple{names}}
     P((getproperty(tp, name) for name ∈ names))
 end
 function set_parameters(tp::TP, p::P) where {P,TP<:TrainablePotential{P}}
@@ -16,7 +16,7 @@ function deserialize_parameters(tp::TrainablePotential{P}, p::AbstractVector) wh
     set_parameters(tp, P(p))
 end
 
-function get_hyperparameters(tp::TrainablePotential{P,HP}) where {P,names,HP<:Parameter{names}}
+function get_hyperparameters(tp::TrainablePotential{P,HP}) where {P,names,HP<:NamedTuple{names}}
     HP((getproperty(tp, name) for name ∈ names))
 end
 function set_hyperparameters(tp::TP, p::HP) where {P,HP,TP<:TrainablePotential{P,HP}}

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -1,18 +1,18 @@
-struct MockArbitraryPotential <: ArbitraryPotential
+struct MockAbstractPotential <: AbstractPotential
     seed::Float64
     species::Tuple
 end
-function InteratomicPotentials.energy_and_force(A::AbstractSystem, p::MockArbitraryPotential)
+function InteratomicPotentials.energy_and_force(A::AbstractSystem, p::MockAbstractPotential)
     (
         e=(p.seed)u"hartree",
         f=fill((@SVector[p.seed + 1, p.seed + 2, p.seed + 3])u"hartree/bohr", length(A))
     )
 end
-function InteratomicPotentials.virial_stress(A::AbstractSystem, p::MockArbitraryPotential)
+function InteratomicPotentials.virial_stress(A::AbstractSystem, p::MockAbstractPotential)
     (@SVector [p.seed - 1, p.seed - 2, p.seed - 3, p.seed - 4, p.seed - 5, p.seed - 6])u"hartree"
 end
 
-struct MockEmpiricalPotential <: EmpiricalPotential{Parameter{},Parameter{}}
+struct MockEmpiricalPotential <: EmpiricalPotential{NamedTuple{},NamedTuple{}}
     seed::Float64
     rcutoff::Float64
     species::Tuple

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -12,7 +12,7 @@ function InteratomicPotentials.virial_stress(A::AbstractSystem, p::MockArbitrary
     (@SVector [p.seed - 1, p.seed - 2, p.seed - 3, p.seed - 4, p.seed - 5, p.seed - 6])u"hartree"
 end
 
-struct MockEmpiricalPotential <: EmpiricalPotential
+struct MockEmpiricalPotential <: EmpiricalPotential{Parameter{},Parameter{}}
     seed::Float64
     rcutoff::Float64
     species::Tuple

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ include("mocks.jl")
         include("unit/unit_convention.jl")
         include("unit/nnlist.jl")
         @testset "Default Implementations" begin
-            include("unit/types/arbitrary_potential.jl")
+            include("unit/types/abstract_potential.jl")
             include("unit/types/empirical_potential.jl")
         end
         @testset "Empirical Potentials" begin

--- a/test/unit/mixed/linear_combination_potential.jl
+++ b/test/unit/mixed/linear_combination_potential.jl
@@ -8,8 +8,8 @@
     box = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]u"bohr"
     system = periodic_system(atoms, box)
 
-    p1 = MockArbitraryPotential(1.0, (:Ar, :H))
-    p2 = MockArbitraryPotential(2.0, (:Ar, :H))
+    p1 = MockAbstractPotential(1.0, (:Ar, :H))
+    p2 = MockAbstractPotential(2.0, (:Ar, :H))
     mixed_potentials = [
         +p1,
         -p1,

--- a/test/unit/types/abstract_potential.jl
+++ b/test/unit/types/abstract_potential.jl
@@ -1,4 +1,4 @@
-@testset "Arbitrary Potential Default Implmentation Unit Tests" begin
+@testset "Abstract Potential Default Implmentation Unit Tests" begin
     atoms = [
         :Ar => (@SVector [0.0, 0.0, 0.0])u"bohr",
         :Ar => (@SVector [0.5, 0.0, 0.0])u"bohr",
@@ -8,7 +8,7 @@
     box = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]u"bohr"
     system = periodic_system(atoms, box)
 
-    p = MockArbitraryPotential(0.0, (:Ar, :H))
+    p = MockAbstractPotential(0.0, (:Ar, :H))
 
     @test potential_energy(system, p) == 0.0u"hartree"
     @test force(system, p) == fill((@SVector[1.0, 2.0, 3.0])u"hartree/bohr", 4)


### PR DESCRIPTION
This PR is a follow-up to #32. My proposal is to update the hierarchy by branching at the root (`AbstractPotential`, renamed from `ArbitraryPotential` into two types: `TrainablePotential` and `NonTrainablePotential`. The `TrainablePotential` automatically handles all of the parameter manipulation and default serialization logic. `NonTrainablePotential` provides default implementations for potentials such as the `DFTKPotential` that don't want to use our interface. Having these defaults allows us to do clever things to concatenate parameter sets for mixed potentials (not implemented yet). Notice how for each empirical potential all we have to do is specify the names of the parameters and hyperparameters. All functionality is equivalent to how it was before this PR.