### PR TITLE
Fix incorrect backticks and formatting in equations.

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -139,31 +139,31 @@ function deserialize_hyperparameters end
 """
     get_local_descriptors(s::AbstractSystem, b::BasisSystem)::Vector{Vector}
 
-Compute the local descriptors for an abstract system s using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
+Compute the local descriptors for an abstract system `s` using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
 
-For a system s with n_atom number of atoms this method get_local_descriptors returns a Vector{Vector{T<:Real}}, containing n_atom vectors each of dimension d as defined by the basis system.
+For a system `s` with `n_atom` number of atoms this method `get_local_descriptors` returns a `Vector{Vector{T<:Real}}`, containing `n_atom` vectors each of dimension `d` as defined by the basis system.
 """
 function compute_local_descriptors end 
 """
     compute_force_descriptors(s::AbstractSystem, b::BasisSystem)::Vector{Vector{Vector}}
 
-Compute the force descriptors for an abstract system s using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
+Compute the force descriptors for an abstract system `s` using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
 
-For a system s with n_atom number of atoms this method compute_force_descriptors returns a Vector{Matrix{T<:Real}}}, containing n_atom vectors each containing a matrix with rows corresponding to x-, y-, and z-components of dimension d as defined by the basis system.
+For a system `s` with `n_atom` number of atoms this method `compute_force_descriptors` returns a `Vector{Matrix{T<:Real}}}`, containing `n_atom` vectors each containing a matrix with rows corresponding to x-, y-, and z-components of dimension `d` as defined by the basis system.
 """
 function compute_force_descriptors end
 """
     compute_virial_descriptors(s::AbstractSystem, b::BasisSystem)::Vector{Vector{Vector}}
 
-Compute the virial descriptors for an abstract system s using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
+Compute the virial descriptors for an abstract system `s` using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
 
-For a system s with n_atom number of atoms this method compute_virial_descriptors returns a Matrix{T<:Real}, containing 6 rows corresponding to entries of the stress tensor and columns of dimension d as defined by the basis system.
+For a system `s` with `n_atom` number of atoms this method `compute_virial_descriptors` returns a `Matrix{T<:Real}`, containing 6 rows corresponding to entries of the stress tensor and columns of dimension `d` as defined by the basis system.
 """
 function compute_virial_descriptors end
 """
     compute_all_descriptors(s::AbstractSystem, b::BasisSystem)::Vector{Vector{Vector}}
 
-Compute the local, force, and virial descriptors for an abstract system s using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
+Compute the local, force, and virial descriptors for an abstract system `s` using the basis system defined in b. These types are defined in this package, but the primary use is in the InteratomicBasisPotentials.jl package, where the individual basis systems are defined. 
 """
 function compute_all_descriptors end
 

--- a/src/empirical/morse.jl
+++ b/src/empirical/morse.jl
@@ -8,12 +8,12 @@ The Morse potential is a simple two-body intermolecular potential with three typ
 V_{M}(r; D, \\alpha, \\sigma, rcutoff, species) =
     \\begin{cases} 
     0 & r > rcutoff \\\\
-    D \\left( 1 - e^{\\alpha(r - \\sigma)}\right)^2 & r < rcutoff.
+    D \\left( 1 - e^{\\alpha(r - \\sigma)}\\right)^2 & r < rcutoff.
     \\end{cases}
 \\end{equation}
 ```
 
-Users must supply three parameters, ``D`` (units of energy), ``\\alpha`` (units of inverse distance), ''\\sigma'' (units of distance), and radial cutoff (units of distance).
+Users must supply three parameters, ``D`` (units of energy), ``\\alpha`` (units of inverse distance), ``\\sigma`` (units of distance), and radial cutoff (units of distance).
 """
 struct Morse{T<:AbstractFloat} <: EmpiricalPotential{NamedTuple{(:D, :α, :σ)},NamedTuple{(:rcutoff,)}}
     D::T

--- a/src/types.jl
+++ b/src/types.jl
@@ -22,7 +22,7 @@ include("types/non_trainable_potential.jl")
     TrainablePotential{P<:NamedTuple,HP<:NamedTuple} <: AbstractPotential
 
 Abstract type for potentials that are trainable.
-`P` is a `NamedTuple` of parameter names and `HP`` is a `NamedTuple`` of hyperparameter names.
+`P` is a `NamedTuple` of parameter names and `HP` is a `NamedTuple` of hyperparameter names.
 """
 abstract type TrainablePotential{P<:NamedTuple,HP<:NamedTuple} <: AbstractPotential end
 include("types/trainable_potential.jl")
@@ -32,7 +32,7 @@ include("types/trainable_potential.jl")
 
 Defines an empirical potential, a heuristic function used to describe the intermolecular potential energy of a configuration of atoms. Various potentials have been found to agree empirically with the experimentally obtained potential energy of a configuration of atoms for particular atoms in particular situations. This package implements a number of such popular potentials.
 
-`P` is a `NamedTuple` of parameter names and `HP`` is a `NamedTuple`` of hyperparameter names.
+`P` is a `NamedTuple` of parameter names and `HP` is a `NamedTuple` of hyperparameter names.
 """
 abstract type EmpiricalPotential{P<:NamedTuple,HP<:NamedTuple} <: TrainablePotential{P,HP} end
 include("types/empirical_potential.jl")


### PR DESCRIPTION
1. Fix backticks wherever necessary. 
2. Fix Morse potential equation formatting. 

Furthermore, add backticks in some places for consistency. Feel free to remove those. 